### PR TITLE
Notebooks/Tropo: fix typo while converting pseudo-range delay to slant phase

### DIFF
--- a/Notebooks/Atmosphere/Troposphere/Tropo.ipynb
+++ b/Notebooks/Atmosphere/Troposphere/Tropo.ipynb
@@ -521,7 +521,7 @@
    },
    "source": [
     "In this chapter we will convert the GACOS pseudo-range zenith tropospheric delays, into the projection reference as the geo-coded interferogram and project the zenith delay to the slant using the incidence angle information.\n",
-    "$$\\Phi_{\\text{slant}}=\\frac{-\\lambda}{4 \\pi* cos(\\theta)}*d_{\\text{zenith}}$$"
+    "$$\\Phi_{\\text{slant}}=\\frac{-4 \\pi}{\\lambda* cos(\\theta)}*d_{\\text{zenith}}$$"
    ]
   },
   {
@@ -799,7 +799,7 @@
    },
    "source": [
     "Next, we will project the zenith delay into the radar slant (radar look direction) by using a simple cosine mapping function of the incidence angle, and at the same time apply the scaling to convert from pseudo-range to phase \n",
-    "$$\\Phi_{\\text{slant}}=\\frac{-\\lambda}{4 \\pi* cos(\\theta)}*d_{\\text{zenith}}$$\n",
+    "$$\\Phi_{\\text{slant}}=\\frac{-4 \\pi}{\\lambda* cos(\\theta)}*d_{\\text{zenith}}$$\n",
     "The **zenith2slant** function included below takes the geocoded zenith APS file as well as the LOS file as inputs and outputs an ENVI geo-coded slant delay file"
    ]
   },
@@ -1080,7 +1080,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fix the typo in the formula to convert the pseudo-range zenith delay in meters from GACOS to the slant range delay in radians, to be consistent with the code.